### PR TITLE
Fix legacy regex fallback for zero-second datetimes

### DIFF
--- a/src/main/java/oryanmoshe/kafka/connect/util/TimestampConverter.java
+++ b/src/main/java/oryanmoshe/kafka/connect/util/TimestampConverter.java
@@ -272,7 +272,7 @@ public class TimestampConverter implements CustomConverter<SchemaBuilder, Relati
     // LEGACY METHOD
     private Long milliFromDateString(String timestamp) {
         // The regex is only for unknown patterns
-        final String DATETIME_REGEX = "(?<datetime>(?<date>(?:(?<year>\\d{4})-(?<month>\\d{1,2})-(?<day>\\d{1,2}))|(?:(?<day2>\\d{1,2})\\/(?<month2>\\d{1,2})\\/(?<year2>\\d{4}))|(?:(?<day3>\\d{1,2})-(?<month3>\\w{3})-(?<year3>\\d{4})))?(?:\\s?T?(?<time>(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2})\\.?(?<milli>\\d{0,7})?)?))";
+        final String DATETIME_REGEX = "(?<datetime>(?<date>(?:(?<year>\\d{4})-(?<month>\\d{1,2})-(?<day>\\d{1,2}))|(?:(?<day2>\\d{1,2})\\/(?<month2>\\d{1,2})\\/(?<year2>\\d{4}))|(?:(?<day3>\\d{1,2})-(?<month3>\\w{3})-(?<year3>\\d{4})))?(?:\\s?T?(?<time>(?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2}))\\.?(?<milli>\\d{0,7})|(?:(?<hour2>\\d{1,2}):(?<minute2>\\d{1,2}))?)?))";
         final Pattern regexPattern = Pattern.compile(DATETIME_REGEX);
 
         Matcher matches = regexPattern.matcher(timestamp);
@@ -284,8 +284,10 @@ public class TimestampConverter implements CustomConverter<SchemaBuilder, Relati
                     : (matches.group("month2") != null ? matches.group("month2") : matches.group("month3")));
             String day = (matches.group("day") != null ? matches.group("day")
                     : (matches.group("day2") != null ? matches.group("day2") : matches.group("day3")));
-            String hour = matches.group("hour") != null ? matches.group("hour") : "00";
-            String minute = matches.group("minute") != null ? matches.group("minute") : "00";
+            String hour = (matches.group("hour") != null ? matches.group("hour")
+                    : (matches.group("hour2") != null ? matches.group("hour2") : "00"));
+            String minute = (matches.group("minute") != null ? matches.group("minute")
+                    : (matches.group("minute2") != null ? matches.group("minute2") : "00"));
             String second = matches.group("second") != null ? matches.group("second") : "00";
             String milli = matches.group("milli") != null ? matches.group("milli") : "000";
 


### PR DESCRIPTION
## Summary

Legacy fallback fix only: When Java's `LocalDateTime.toString()` omits `:00` seconds (e.g., `2023-04-15T12:34` instead of `2023-04-15T12:34:00`), the legacy fallback regex in `milliFromDateString` fails to match the time portion, zeroing it out.

**Before:** `2023-04-15T12:34` → `2023-04-15T00:00:00.000Z`
**After:** `2023-04-15T12:34` → `2023-04-15T12:34:00.000Z`

This affects ~1 in 60 MySQL `DATETIME` values (whenever seconds happen to be `:00`) assuming random spread.  For a real example, it affected ~1.8% of our rows over a few months while we diagnosed this.  This likely won't have a real effect unless the legacy method is called.

## Approach

The primary `DateTimeFormatter` code path already handles this via `NO_SECONDS_FORMATS`. This PR fixes the **legacy regex fallback** (`milliFromDateString`) by adding an explicit alternate branch for hour:minute-only times, rather than making colons optional (which would also match invalid formats like `123456`).

This is the same fix from [oryanmoshe/debezium-timestamp-converter#21](https://github.com/oryanmoshe/debezium-timestamp-converter/pull/21), adapted for the RiveryIO fork's legacy fallback path. Thanks @nadflinn

## Test plan

- [ ] Existing tests continue to pass
- [ ] Verify `2023-04-15T12:34` parses correctly in the legacy fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)